### PR TITLE
fix: corrected the "order" parameter for requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ type Params struct {
 	Limit     string
 	Query     string
 	Filter    map[string]string
-	Order     string
+	Order     string //Format: "created_at,desc" [ 1 - field, 2 - direction]
 	ContactID string
 	ChatID    string
 }

--- a/misc.go
+++ b/misc.go
@@ -190,9 +190,13 @@ func isParams(req *fiber.Request, domain string, parameter string, params *Param
 			field.Name = "chat_id"
 		}
 		if field.Name == "Order" && value != "" {
-			orderSetting := strings.Split(value, ",")
-			field.Name = fmt.Sprintf("order[%s]", orderSetting[0])
-			value = orderSetting[1]
+			orderSetting := strings.SplitN(value, ",", 2)
+			if len(orderSetting) == 2 && orderSetting[0] != "" && orderSetting[1] != "" {
+				field.Name = fmt.Sprintf("order[%s]", orderSetting[0])
+				value = orderSetting[1]
+			} else {
+				value = ""
+			}
 		}
 		if value != "" && field.Type != reflect.TypeOf(With{}) && field.Name != "Filter" {
 			q.Set(strings.ToLower(field.Name), value)

--- a/misc.go
+++ b/misc.go
@@ -2,6 +2,7 @@ package amocrm
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/url"
 	"reflect"
@@ -187,6 +188,11 @@ func isParams(req *fiber.Request, domain string, parameter string, params *Param
 		}
 		if field.Name == "ChatID" {
 			field.Name = "chat_id"
+		}
+		if field.Name == "Order" && value != "" {
+			orderSetting := strings.Split(value, ",")
+			field.Name = fmt.Sprintf("order[%s]", orderSetting[0])
+			value = orderSetting[1]
 		}
 		if value != "" && field.Type != reflect.TypeOf(With{}) && field.Name != "Filter" {
 			q.Set(strings.ToLower(field.Name), value)


### PR DESCRIPTION
Добавил в поле "Order" возможность выбирать параметр сортировки и направление через запятую.
По документации амо параметр может быть в каждом запросе свой, значения для сортировки: asc, desc.

Пример:

```
Order: "updated_at,desc"
```

